### PR TITLE
docs: Rename to adapter / add WIP warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# ⚡️Fleek Proxy
+# ⚡️Fleek Next Adapter
 
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-blue.svg)](https://conventionalcommits.org)
 
-The Fleek Next CLI allows you to deploy your server-side Next.js application on Fleek. This CLI is currently in an experimental stage.
+The Fleek Next.js adapter allows you to deploy your server-side Next.js application on Fleek.
 
 # 🚧 Work in Progress 🚧
 
@@ -42,7 +42,7 @@ export FLEEK_PAT=<your personal access token>
 
 3. **Build and Deploy**
 
-Use the Fleek Next CLI to build and deploy your application:
+Use the Fleek Next.js adapter to build and deploy your application via the command line:
 
 ```sh
 npx fleek-next build

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 The Fleek Next CLI allows you to deploy your server-side Next.js application on Fleek. This CLI is currently in an experimental stage.
 
+# 🚧 Work in Progress 🚧
+
+This repository is currently under development and is a **Work in Progress**. Features and functionalities may change frequently.
+
 # Installation
 
 - **npm**


### PR DESCRIPTION
## Why?

Rename the tool from CLI to adapter which is more suitable. Add WIP warning as this tool is still very early stages.

## How?

- Updated readme file

## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [x] Assets or static content are linked and stored in the project
- [x] Document filename is named after the slug
- [x] You've reviewed spelling using a grammar checker
- [x] For documentation, guides or references, you've tested the commands and steps
- [x] You've done enough research before writing

## Security checklist?

- [x] Sensitive data has been identified and is being protected properly
- [x] Injection has been prevented (parameterized queries, no eval or system calls)
- [x] The Components are escaping output (to prevent XSS)
